### PR TITLE
Regex fixes and added check-contents parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ For general information on how SublimeLinter works with settings, please see [Se
 |all|If set to true, the liner will use pass --all to `flow check` which will check every javascript file regardless of whether they have the `/* @flow */` declaration at the top. [More info](http://flowtype.org/docs/new-project.html#typechecking-your-files)|
 |lib|Add a path to your interface files. [More info](http://flowtype.org/docs/third-party.html#interface-files)|
 |show-all-errors|It allows flow to output all errors instead of stopping at 50|
+|use-server|If set to true, runs `flow status` instead of `flow check`. The former starts a server (if not started already) to speed it up|
+|lint-view|If set to true, runs `check-contents` instead of any other command. This ignores the `use-server` derective and starts a server, since it's required flow |
 
 ### Warning
 

--- a/linter.py
+++ b/linter.py
@@ -10,8 +10,10 @@
 
 """This module exports the Flow plugin class."""
 
-import os, re
+import os
+import re
 from SublimeLinter.lint import Linter
+
 
 class Flow(Linter):
 
@@ -71,7 +73,7 @@ class Flow(Linter):
         if self.get_merged_settings()['all']:
             if 'check' in command or 'status' in command:
                 command.append('--all')
-                
+
         # TODO: Not tested but seemed like a good thing to add
         if self.get_merged_settings()['lib'] and len(self.get_merged_settings()['lib']) > 0:
             command.append('--lib')
@@ -86,15 +88,15 @@ class Flow(Linter):
         """Run the linting command and return the results."""
         if self.get_merged_settings()['lint-view']:
             # check for the @flow declaration. Currently only has to be somewhere in the file.
-            if self.get_merged_settings()['all'] or re.match( r'\s*\/\*\s*\@flow\s*\*\/', code):
+            if self.get_merged_settings()['all'] or re.match(r'\s*\/\*\s*\@flow\s*\*\/', code):
                 # Since the linter has no knowlage about files, add the filepath to
                 # function with the default filepath to reflect the default function behaviour
-                result = self.communicate(cmd, code).replace('-:',self.filename + ":")
+                result = self.communicate(cmd, code).replace('-:', self.filename + ":")
                 return result
             else:
                 return ''
         else:
-            return super().run(cmd,code)
+            return super().run(cmd, code)
 
     def split_match(self, match):
         """
@@ -112,14 +114,14 @@ class Flow(Linter):
                 message_title = match.group('message_title')
                 message = match.group('message')
                 message_footer = match.group('message_footer')
-                message_format = [];
+                message_format = []
 
                 if message_title:
-                    message_format.append('[ {0} ]');
+                    message_format.append('[ {0} ]')
                 if message:
-                    message_format.append('{1}');
+                    message_format.append('{1}')
                 if message_footer:
-                    message_format.append('[ {2} ]');
+                    message_format.append('[ {2} ]')
 
                 message = " ".join(message_format).format(
                     message_title,
@@ -133,7 +135,7 @@ class Flow(Linter):
                 col_start, col_end = (int(part) for part in match.group('col').split(','))
                 col_start -= 1
                 # Get the length of the column section for length of error
-                near = " " * (col_end - col_start);
+                near = " " * (col_end - col_start)
 
                 # match, line, col, error, warning, message, near
                 return match, line, col_start, True, False, message, near

--- a/linter.py
+++ b/linter.py
@@ -48,8 +48,9 @@ class Flow(Linter):
         # Allows flow to start server (makes things faster on larger projects)
         'use-server': True,
 
+        # TODO: Remove the parameter if deemed unececerry
         # Options for flow
-        'lib:,': ''
+        # 'lib:,': ''
     }
     word_re = r'^((\'|")?[^"\']+(\'|")?)(?=[\s\,\)\]])'
     selectors = {
@@ -74,10 +75,10 @@ class Flow(Linter):
             if 'check' in command or 'status' in command:
                 command.append('--all')
 
-        # TODO: Not tested but seemed like a good thing to add
-        if self.get_merged_settings()['lib'] and len(self.get_merged_settings()['lib']) > 0:
-            command.append('--lib')
-            command.append(self.get_merged_settings()['lib'])
+        # TODO: Remove the parameter if deemed unececerry.
+        # if self.get_merged_settings()['lib'] and len(self.get_merged_settings()['lib']) > 0:
+        #    command.append('--lib')
+        #    command.append(self.get_merged_settings()['lib'])
 
         if self.get_merged_settings()['show-all-errors']:
             command.append('--show-all-errors')

--- a/linter.py
+++ b/linter.py
@@ -87,12 +87,14 @@ class Flow(Linter):
 
     def run(self, cmd, code):
         """Run the linting command and return the results."""
+
         if self.get_merged_settings()['lint-view']:
             # check for the @flow declaration. Currently only has to be somewhere in the file.
             if self.get_merged_settings()['all'] or re.match(r'\s*\/\*\s*\@flow\s*\*\/', code):
                 # Since the linter has no knowlage about files, add the filepath to
                 # function with the default filepath to reflect the default function behaviour
-                result = self.communicate(cmd, code).replace('-:', self.filename + ":")
+                cmd.append(self.filename)
+                result = self.communicate(cmd, code)
                 return result
             else:
                 return ''


### PR DESCRIPTION
I've tried dividing up the changes into smaller chunks to make it easier to review the changes.

Summary:
1. Edited the regex to get the column in the format 00,00 instead of only the first part 00. Also made the 'main message' optional.
2. Added two new directives 'lint-view' and 'use-server'. I also saw that 'use-server' also was requested in another pull request, so wrote this code in the same way.
4. Added more advanced linter run rules to allow grabbing the code directly out of the view buffer.
5. Changed the view formatting and added a more specific selection for the linter highlighter through the near variable.

I understand that the 'lint-view' might not be perfect, but it fixes the problem that flow otherwise lints the file on disk, which can cause weird behaviour when highlighting. It also enables inline linting of files, for example in html and php documents. 