### PR TITLE
use `--no-auto-start` to replace `status`, so that the plugin will not pollute the environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ For general information on how SublimeLinter works with settings, please see [Se
 |all|If set to true, the liner will use pass --all to `flow check` which will check every javascript file regardless of whether they have the `/* @flow */` declaration at the top. [More info](http://flowtype.org/docs/new-project.html#typechecking-your-files)|
 |lib|Add a path to your interface files. [More info](http://flowtype.org/docs/third-party.html#interface-files)|
 |show-all-errors|It allows flow to output all errors instead of stopping at 50|
+|use-server|If set to true, runs `flow status` instead of `flow check`. The former starts a server (if not started already) to speed it up|
 
 ### Warning
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For general information on how SublimeLinter works with settings, please see [Se
 |all|If set to true, the liner will use pass --all to `flow check` which will check every javascript file regardless of whether they have the `/* @flow */` declaration at the top. [More info](http://flowtype.org/docs/new-project.html#typechecking-your-files)|
 |lib|Add a path to your interface files. [More info](http://flowtype.org/docs/third-party.html#interface-files)|
 |show-all-errors|It allows flow to output all errors instead of stopping at 50|
-|use-server|If set to true, runs `flow status` instead of `flow check`. The former starts a server (if not started already) to speed it up|
+|use-server|If set to true, runs `flow --no-auto-start` instead of `flow check`. The former fetch results from an existing server (If there is no existing flow server, nothing will be done. You can use `flow start` to start a server) to speed it up|
 
 ### Warning
 

--- a/linter.py
+++ b/linter.py
@@ -57,7 +57,7 @@ class Flow(Linter):
         command = [self.executable_path]
 
         if self.get_merged_settings()['use-server']:
-            command.append('status')
+            command.append('--no-auto-start')
         else:
             command.append('check')
 

--- a/linter.py
+++ b/linter.py
@@ -41,6 +41,9 @@ class Flow(Linter):
         # Allow to bypass the 50 errors cap
         'show-all-errors': True,
 
+        # Allows flow to start server (makes things faster on larger projects)
+        'use-server': True,
+
         # Options for flow
         '--lib:,': ''
     }
@@ -51,7 +54,12 @@ class Flow(Linter):
 
     def cmd(self):
         """Return the command line to execute."""
-        command = [self.executable_path, 'status']
+        command = [self.executable_path]
+
+        if self.get_merged_settings()['use-server']:
+            command.append('status')
+        else:
+            command.append('check')
 
         if self.get_merged_settings()['show-all-errors']:
             command.append('--show-all-errors')

--- a/linter.py
+++ b/linter.py
@@ -11,6 +11,7 @@
 """This module exports the Flow plugin class."""
 
 import os
+import sublime
 from SublimeLinter.lint import Linter
 
 
@@ -97,9 +98,11 @@ class Flow(Linter):
                 col = int(match.group('col')) - 1
                 another_line = int(match.group('another_line') or line)
                 col_end = int(match.group('col_end'))
-                near_length = self.view.text_point(another_line, col_end) - self.view.text_point(line, col)
+                near_start_point = self.view.text_point(line, col)
+                near_end_point = self.view.text_point(another_line, col_end)
+                near = self.view.substr(sublime.Region(near_start_point, near_end_point))
 
                 # match, line, col, error, warning, message, near
-                return match, line, col, True, False, message, " " * near_length
+                return match, line, col, True, False, message, near
 
         return match, None, None, None, None, '', None

--- a/linter.py
+++ b/linter.py
@@ -25,7 +25,7 @@ class Flow(Linter):
     version_requirement = '>= 0.1.0'
     regex = r'''(?xi)
         # Warning location and optional title for the message
-        ^.+/(?P<file_name>[^/]+\.(js|html)):(?P<line>\d+):(?P<col>\d+),\d+:\s*(?P<message_title>.+)$\r?\n
+        ^.+/(?P<file_name>[^/]+\.(js|html|jsx)):(?P<line>\d+):(?P<col>\d+),\d+:\s*(?P<message_title>.+)$\r?\n
 
         # Main lint message
         ^(?P<message>.+)$

--- a/linter.py
+++ b/linter.py
@@ -51,7 +51,7 @@ class Flow(Linter):
 
     def cmd(self):
         """Return the command line to execute."""
-        command = [self.executable_path, 'check']
+        command = [self.executable_path, 'status']
 
         if self.get_merged_settings()['show-all-errors']:
             command.append('--show-all-errors')

--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,7 @@ class Flow(Linter):
 
     """Provides an interface to flow."""
 
-    syntax = ('javascript', 'html')
+    syntax = ('javascript', 'html', 'javascriptnext', 'javascript (babel)', 'javascript (jsx)', 'jsx')
     executable = 'flow'
     version_args = '--version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'

--- a/linter.py
+++ b/linter.py
@@ -25,7 +25,7 @@ class Flow(Linter):
     version_requirement = '>= 0.1.0'
     regex = r'''(?xi)
         # Warning location and optional title for the message
-        ^.+/(?P<file_name>[^/]+\.(js|html|jsx)):(?P<line>\d+):(?P<col>\d+),\d+:\s*(?P<message_title>.+)$\r?\n
+        ^.+/(?P<file_name>[^/]+\.(js|html|jsx)):(?P<line>\d+):(?P<col>\d+),((?P<another_line>\d+):)?(?P<col_end>\d+):\s*(?P<message_title>.+)$\r?\n
 
         # Main lint message
         ^(?P<message>.+)$
@@ -95,8 +95,11 @@ class Flow(Linter):
 
                 line = max(int(match.group('line')) - 1, 0)
                 col = int(match.group('col')) - 1
+                another_line = int(match.group('another_line') or line)
+                col_end = int(match.group('col_end'))
+                near_length = self.view.text_point(another_line, col_end) - self.view.text_point(line, col)
 
                 # match, line, col, error, warning, message, near
-                return match, line, col, True, False, message, None
+                return match, line, col, True, False, message, " " * near_length
 
         return match, None, None, None, None, '', None

--- a/linter.py
+++ b/linter.py
@@ -31,7 +31,7 @@ class Flow(Linter):
         ^(?P<message>.+)$
 
         # Optional message, only extract the text, leave the path
-        (\r?\n\s\s/.+:\s(?P<message_footer>.+))?
+        (\r?\n\s?\s?/.+:\s(?P<message_footer>.+)(?=\r?\n$))?
     '''
     multiline = True
     defaults = {


### PR DESCRIPTION
The plugin should not start a server, which is not a plugin's resposibility. If a user choose the option of ` use-server`, then the plugin should just fecth the info from an existing server. If the server is not exist, it should just do noting.