### PR TITLE
Add support for javascript (babel) sytnax

### DIFF
--- a/linter.py
+++ b/linter.py
@@ -18,7 +18,7 @@ class Flow(Linter):
 
     """Provides an interface to flow."""
 
-    syntax = ('javascript', 'html')
+    syntax = ('javascript', 'javascript (babel)', 'html')
     executable = 'flow'
     version_args = '--version'
     version_re = r'(?P<version>\d+\.\d+\.\d+)'


### PR DESCRIPTION
the `javascript (babel)` syntax is added by [babel-sublime](https://github.com/babel/babel-sublime)